### PR TITLE
feature: add more detail fields in api-table component

### DIFF
--- a/apps/raddix/data/docs/utilities/use-scroll-spy/use-scroll-spy.en.mdx
+++ b/apps/raddix/data/docs/utilities/use-scroll-spy/use-scroll-spy.en.mdx
@@ -73,17 +73,20 @@ The `useScrollSpy` hook accepts an object with the Intersection Observer API opt
     {
       name: 'root',
       description:
-        'The element that is used as the viewport for checking visibility of the target.'
+        'The element that is used as the viewport for checking visibility of the target.',
+      required: 'No'
     },
     {
       name: 'rootMargin',
       description:
-        'Margin around the root. Can have values similar to the CSS margin property.'
+        'Margin around the root. Can have values similar to the CSS margin property.',
+      required: 'No'
     },
     {
       name: 'threshold',
       description:
-        "Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed."
+        "Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed.",
+      required: 'No'
     }
   ]}
 />

--- a/apps/raddix/data/docs/utilities/use-scroll-spy/use-scroll-spy.es.mdx
+++ b/apps/raddix/data/docs/utilities/use-scroll-spy/use-scroll-spy.es.mdx
@@ -56,6 +56,11 @@ Detrás de cámaras, el hook utiliza el Intersection Observer Web API, así que 
 ### Resultado
 
 <ApiTable
+  head={{
+    name: 'Nombre',
+    description: 'Descripción',
+    type: 'Tipo'
+  }}
   data={[
     {
       name: 'activeId',
@@ -70,21 +75,34 @@ Detrás de cámaras, el hook utiliza el Intersection Observer Web API, así que 
 El hook `useScrollSpy` acepta un objeto con propiedades del Intersection Observer API.
 
 <ApiTable
+  head={
+    {
+      name: 'Nombre',
+      description: 'Descripción',
+      required: 'Requerido',
+      type: 'Tipo'
+    }
+  }
   data={[
     {
       name: 'root',
       description:
-        'El elemento que se utiliza como ventana gráfica para comprobar la visibilidad del objetivo.'
+        'El elemento que se utiliza como ventana gráfica para comprobar la visibilidad del objetivo.',
+      required: 'No',
+
     },
     {
       name: 'rootMargin',
       description:
-        'Margen alrededor de la raíz. Puede tener valores similares a la margin propiedad CSS.'
+        'Margen alrededor de la raíz. Puede tener valores similares a la margin propiedad CSS.',
+      required: 'No',
     },
     {
       name: 'threshold',
       description:
-        'Ya sea un solo número o una serie de números que indican en qué porcentaje de la visibilidad del objetivo se debe ejecutar la devolución de llamada del observador.'
+        'Ya sea un solo número o una serie de números que indican en qué porcentaje de la visibilidad del objetivo se debe ejecutar la devolución de llamada del observador.',
+      required: 'No',
     }
-  ]}
+
+]}
 />

--- a/apps/raddix/src/components/api-table.tsx
+++ b/apps/raddix/src/components/api-table.tsx
@@ -1,6 +1,11 @@
+import { useRouter } from 'next/router';
+
 interface Option {
   name: string;
   description: string;
+  required?: string;
+  defaultValue?: string;
+  type: string;
 }
 
 export interface ApiTableProps {
@@ -10,28 +15,56 @@ export interface ApiTableProps {
 
 export const ApiTable = ({ head, data }: ApiTableProps) => {
   return (
-    <table className='mt-sm w-full border-collapse text-left'>
+    <table className='mt-sm block w-full table-fixed border-collapse overflow-x-auto text-left scrollbar-thin scrollbar-track-[transparent] scrollbar-thumb-gray-40/50 scrollbar-thumb-rounded-lg'>
       <thead>
         <tr>
-          <th className='w-1/4 bg-white/5 p-xs text-sm font-medium'>
+          <th className='whitespace-nowrap bg-white/5 p-xs text-sm font-medium'>
             {head?.name ?? 'Name'}
           </th>
-          <th className='w-3/4 bg-white/5 p-xs text-sm font-medium'>
+          <th className='whitespace-nowrap bg-white/5 p-xs text-sm font-medium'>
             {head?.description ?? 'Description'}
+          </th>
+          {(head?.required || data[0].required) && (
+            <th className='whitespace-nowrap bg-white/5 p-xs text-sm font-medium'>
+              {head?.required ?? 'Required'}
+            </th>
+          )}
+          {(head?.defaultValue || data[0].defaultValue) && (
+            <th className='whitespace-nowrap bg-white/5 p-xs text-sm font-medium'>
+              {head?.defaultValue ?? 'Default Value'}
+            </th>
+          )}
+          <th className='whitespace-nowrap bg-white/5 p-xs text-sm font-medium'>
+            {head?.type ?? 'Type'}
           </th>
         </tr>
       </thead>
       <tbody>
-        {data.map(({ name, description }, index) => (
-          <tr key={`${name}-${index}`}>
-            <td className='w-1/4 border-b border-solid border-white/5 px-xs py-sm text-xs '>
-              {name}
-            </td>
-            <td className='w-3/4 border-b border-solid border-white/5 px-xs py-sm text-xs '>
-              {description}
-            </td>
-          </tr>
-        ))}
+        {data.map(
+          ({ name, description, required, defaultValue, type }, index) => (
+            <tr key={`${name}-${index}`} className=''>
+              <td className='border-b border-solid border-white/5 px-xs py-sm text-xs'>
+                {name}
+              </td>
+              <td className='w-5/6 min-w-[25ch] border-b border-solid border-white/5 px-xs py-sm text-xs '>
+                {description}
+              </td>
+              {(head?.required || data[0].required) && (
+                <td className='border-b border-solid border-white/5 px-xs py-sm text-xs '>
+                  {required}
+                </td>
+              )}
+              {(head?.defaultValue || data[0].defaultValue) && (
+                <td className='border-b border-solid border-white/5 px-xs py-sm text-xs '>
+                  {defaultValue}
+                </td>
+              )}
+              <td className='border-b border-solid border-white/5 px-xs py-sm text-xs'>
+                {type}
+              </td>
+            </tr>
+          )
+        )}
       </tbody>
     </table>
   );

--- a/settings/tailwind/tailwind.config.js
+++ b/settings/tailwind/tailwind.config.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     extend: {
       gridTemplateColumns: {
-        ax1xa: 'auto 1fr auto',
+        ax1xa: 'auto minmax(0, 1fr) auto',
         ax1: 'auto 1fr'
       },
       spacing: {


### PR DESCRIPTION
change tailwind style "ax1xa" to "auto minmax(0, 1fr) auto" value because table would extend and so the article tag. Now it respects available space