### PR TITLE
fix: the design of the document is out of balance

### DIFF
--- a/apps/raddix/src/components/search-bar.tsx
+++ b/apps/raddix/src/components/search-bar.tsx
@@ -5,7 +5,7 @@ interface SearchBarProps {
 export const SearchBar = ({ toggle }: SearchBarProps) => {
   return (
     <button
-      className='flex w-60 max-w-full items-center justify-between rounded-xl bg-gray-120 px-4 py-2 transition-colors duration-100 hover:bg-gray-110'
+      className='flex w-full max-w-full items-center justify-between rounded-xl bg-gray-120 px-4 py-2 transition-colors duration-100 hover:bg-gray-110'
       type='button'
       onClick={toggle}
     >

--- a/apps/raddix/src/layouts/docs.tsx
+++ b/apps/raddix/src/layouts/docs.tsx
@@ -38,7 +38,7 @@ export const DocsLayout = ({ children, sidebar, meta }: DocsProps) => {
             <SidebarMenu menu={sidebar} currentRoute={currentSlug} />
           </Sidebar>
         )}
-        <article>
+        <article className='box-border overflow-hidden md:px-md'>
           <section>{children}</section>
           <Pagination menu={sidebar} currentRoute={currentSlug} />
         </article>

--- a/packages/vintex/src/pagenav/pagenav.tsx
+++ b/packages/vintex/src/pagenav/pagenav.tsx
@@ -97,7 +97,7 @@ export const PageNav = ({ locale, path }: PageNavProps) => {
   });
 
   return (
-    <nav className='sticky top-[125px] w-64 self-start pl-md'>
+    <nav className='sticky top-[125px] w-56 self-start'>
       <h5 className='mb-sm text-sm font-medium'>{pageNavTitle}</h5>
       <Tree navData={headings} activeItem={activeHeading} />
     </nav>


### PR DESCRIPTION
On certain pages of the documentation the `article` tag becomes larger than the set width and pushes the `nav` tag out of place, breaking the set grid.