### PR TITLE
feat(raddix): add redirect for hooks documentation.

### DIFF
--- a/apps/raddix/next.config.js
+++ b/apps/raddix/next.config.js
@@ -7,6 +7,15 @@ const nextConfig = {
     locales: ['en', 'es'],
     defaultLocale: 'en',
     localeDetection: false
+  },
+  async redirects() {
+    return [
+      {
+        source: '/hooks/:slug',
+        destination: '/docs/hooks/:slug',
+        permanent: true
+      }
+    ];
   }
 };
 


### PR DESCRIPTION
Add the `redirect` key in `next.config.js` to redirect the request path `/hooks/<hook-name>` to the path `/docs/hooks/<hook-name>`