### PR TITLE
feat(raddix): Update the documentation design.

### DIFF
--- a/apps/raddix/src/components/api-table.tsx
+++ b/apps/raddix/src/components/api-table.tsx
@@ -1,5 +1,3 @@
-import { useRouter } from 'next/router';
-
 interface Option {
   name: string;
   description: string;

--- a/apps/raddix/src/components/button.tsx
+++ b/apps/raddix/src/components/button.tsx
@@ -1,7 +1,7 @@
+import type { TextStr } from '@/types/global';
 import Link from 'next/link';
 
-interface ButtonProps {
-  text: string;
+interface ButtonProps extends TextStr {
   to?: string;
   type: 'primary' | 'secondary';
 }

--- a/apps/raddix/src/components/code-block/code-block.tsx
+++ b/apps/raddix/src/components/code-block/code-block.tsx
@@ -36,15 +36,10 @@ export const CodeBlock = ({
 
   return (
     <div className='flex w-full flex-col rounded-xl border border-solid border-white/5 bg-gray-120/80 backdrop-blur backdrop-saturate-100'>
-      <div className='flex justify-start gap-1.5 px-sm py-4'>
-        <span className='h-3 w-3 rounded-full bg-[#f31260]'></span>
-        <span className='h-3 w-3 rounded-full bg-[#f5a524]'></span>
-        <span className='h-3 w-3 rounded-full bg-[#17c964]'></span>
-      </div>
       <Highlight code={source.trim()} language={language} theme={blameTheme}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre
-            className={`${className} relative box-content flex w-full overflow-hidden py-xs text-xs leading-5`}
+            className={`${className} relative box-content flex w-full overflow-hidden py-md text-xs leading-5 md:text-[14.5px] md:leading-[21px]`}
             style={{
               ...style
             }}
@@ -71,10 +66,10 @@ export const CodeBlock = ({
               </div>
             )}
             <div
-              className='h-[inherit] w-[calc(100%_-_12px)] overflow-auto scrollbar-thin scrollbar-track-[transparent] scrollbar-thumb-gray-40/50 scrollbar-thumb-rounded-lg'
+              className='mx-auto h-[inherit] w-[calc(100%_-_45px)] overflow-auto scrollbar-thin scrollbar-track-[transparent] scrollbar-thumb-gray-40/50 scrollbar-thumb-rounded-lg'
               ref={refCodeWindow}
             >
-              <div className='w-fit min-w-full overflow-hidden px-sm pb-sm'>
+              <div className='w-fit min-w-full overflow-hidden'>
                 {tokens.map((line, i) => {
                   return (
                     <div {...getLineProps({ line })} translate='no' key={i}>

--- a/apps/raddix/src/components/code-block/code-block.tsx
+++ b/apps/raddix/src/components/code-block/code-block.tsx
@@ -3,6 +3,7 @@ import { Highlight } from 'prism-react-renderer';
 import type { TokenOutputProps } from 'prism-react-renderer';
 import { useScroll } from '@/hooks/useScroll';
 import { blameTheme } from './theme';
+import { Copy } from '../copy';
 
 export interface CodeBlockProps {
   source: string;
@@ -35,7 +36,8 @@ export const CodeBlock = ({
   };
 
   return (
-    <div className='flex w-full flex-col rounded-xl border border-solid border-white/5 bg-gray-120/80 backdrop-blur backdrop-saturate-100'>
+    <div className='relative flex w-full flex-col rounded-xl border border-solid border-white/5 bg-gray-120/80 backdrop-blur backdrop-saturate-100'>
+      <Copy text={source} />
       <Highlight code={source.trim()} language={language} theme={blameTheme}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre

--- a/apps/raddix/src/components/code.tsx
+++ b/apps/raddix/src/components/code.tsx
@@ -1,4 +1,4 @@
-import { type Children } from './mdx';
+import type { Children } from '@/types/global';
 
 export const Code = ({ children }: Children) => {
   return (

--- a/apps/raddix/src/components/code.tsx
+++ b/apps/raddix/src/components/code.tsx
@@ -1,0 +1,9 @@
+import { type Children } from './mdx';
+
+export const Code = ({ children }: Children) => {
+  return (
+    <code className='rounded-md bg-gray-110 px-[4px] py-[2.8px] text-xs leading-5 md:px-[6px] md:py-[4px] md:text-[15px] md:leading-[23px]'>
+      {children}
+    </code>
+  );
+};

--- a/apps/raddix/src/components/code.tsx
+++ b/apps/raddix/src/components/code.tsx
@@ -2,7 +2,7 @@ import type { Children } from '@/types/global';
 
 export const Code = ({ children }: Children) => {
   return (
-    <code className='rounded-md bg-gray-110 px-[4px] py-[2.8px] text-xs leading-5 md:px-[6px] md:py-[4px] md:text-[15px] md:leading-[23px]'>
+    <code className='rounded-md bg-gray-110 px-[4px] py-[2.8px] text-xs leading-5 text-white/90 md:px-[6px] md:py-[4px] md:text-[15px] md:leading-[23px]'>
       {children}
     </code>
   );

--- a/apps/raddix/src/components/copy.tsx
+++ b/apps/raddix/src/components/copy.tsx
@@ -1,6 +1,7 @@
+import type { TextStr } from '@/types/global';
 import { useState } from 'react';
 
-export const Copy = ({ text }: { text: string }) => {
+export const Copy = ({ text }: TextStr) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const copyButtonStyles = isCopied

--- a/apps/raddix/src/components/copy.tsx
+++ b/apps/raddix/src/components/copy.tsx
@@ -6,7 +6,7 @@ export const Copy = ({ text }: TextStr) => {
 
   const copyButtonStyles = isCopied
     ? 'bg-blue-40 text-white'
-    : 'hover:bg-gray-100';
+    : 'hover:bg-gray-100 bg-[#141419]';
 
   const handleCopy = (str: string) => {
     if (isCopied) {

--- a/apps/raddix/src/components/copy.tsx
+++ b/apps/raddix/src/components/copy.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+export const Copy = ({ text }: { text: string }) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyButtonStyles = isCopied
+    ? 'bg-blue-40 text-white'
+    : 'hover:bg-gray-100';
+
+  const handleCopy = (str: string) => {
+    if (isCopied) {
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(str)
+      .then(() => setIsCopied(true))
+      .catch(err => console.log(err));
+
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  return (
+    <button
+      className={`absolute right-3 top-4 z-10 rounded-md p-1 md:right-4 md:top-5 ${copyButtonStyles}`}
+      type='button'
+      onClick={() => handleCopy(text)}
+    >
+      {!isCopied ? (
+        <svg
+          className='h-5 w-5'
+          fill='none'
+          height='24'
+          shapeRendering='geometricPrecision'
+          stroke='currentColor'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          strokeWidth='1.5'
+          viewBox='0 0 24 24'
+          width='24'
+          aria-hidden='true'
+        >
+          <path d='M6 17C4.89543 17 4 16.1046 4 15V5C4 3.89543 4.89543 3 6 3H13C13.7403 3 14.3866 3.4022 14.7324 4M11 21H18C19.1046 21 20 20.1046 20 19V9C20 7.89543 19.1046 7 18 7H11C9.89543 7 9 7.89543 9 9V19C9 20.1046 9.89543 21 11 21Z'></path>
+        </svg>
+      ) : (
+        <svg
+          className='h-5 w-5'
+          fill='none'
+          height='24'
+          shapeRendering='geometricPrecision'
+          stroke='currentColor'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          strokeWidth='1.5'
+          viewBox='0 0 24 24'
+          width='24'
+          aria-hidden='true'
+        >
+          <path d='M20 6L9 17l-5-5'></path>
+        </svg>
+      )}
+    </button>
+  );
+};

--- a/apps/raddix/src/components/mdx.tsx
+++ b/apps/raddix/src/components/mdx.tsx
@@ -73,7 +73,10 @@ export const MDXComponents = {
     </Text>
   ),
   p: ({ children }: Children) => (
-    <Text as='p' className='my-sm text-sm tracking-[-.010em] md:text-md'>
+    <Text
+      as='p'
+      className='my-sm text-sm tracking-[-.010em] text-white/90 md:text-md'
+    >
       {children}
     </Text>
   ),
@@ -82,7 +85,7 @@ export const MDXComponents = {
     <ul className='my-sm pl-[20px]'>{children}</ul>
   ),
   li: ({ children }: Children) => (
-    <li className='mb-xs list-disc pl-1 text-sm text-gray-10 md:text-md '>
+    <li className='mb-xs list-disc pl-1 text-sm text-white/90 md:text-md '>
       {children}
     </li>
   ),

--- a/apps/raddix/src/components/mdx.tsx
+++ b/apps/raddix/src/components/mdx.tsx
@@ -34,29 +34,11 @@ export interface TextPreProps {
 }
 
 export const TextPre = (props: Children) => {
-  const [isCopied, setIsCopied] = useState(false);
-
   const children = props.children as TextPreProps;
 
   const classNameRo = children.props.className || '';
   const code = children.props.children;
   const language = classNameRo.replace(/language-/, '');
-
-  const copyButtonStyles = isCopied
-    ? 'bg-blue-60 text-white'
-    : 'bg-white/70 text-gray-90';
-  const handleCopy = (str: string) => {
-    if (isCopied) {
-      return;
-    }
-
-    navigator.clipboard
-      .writeText(str)
-      .then(() => setIsCopied(true))
-      .catch(err => console.log(err));
-
-    setTimeout(() => setIsCopied(false), 2000);
-  };
 
   if (language === 'sh' || language === 'bash') {
     return <Snippet text={code} />;

--- a/apps/raddix/src/components/mdx.tsx
+++ b/apps/raddix/src/components/mdx.tsx
@@ -44,14 +44,18 @@ export const TextPre = (props: Children) => {
 
 export const MDXComponents = {
   h1: ({ children, ...props }: Children) => (
-    <Text as='h1' className='text-3xl font-semibold md:text-4xl' {...props}>
+    <Text
+      as='h1'
+      className='pb-[3px] text-[2.6rem] font-bold leading-[1.16] tracking-[-.04em] md:pb-[6px] md:text-[3.2rem] md:leading-[1.12] md:tracking-[-.042em]'
+      {...props}
+    >
       {children}
     </Text>
   ),
   h2: ({ children, ...props }: Children) => (
     <Text
       as='h2'
-      className='mb-sm mt-2xl text-2xl font-semibold md:pt-xs'
+      className='mb-sm mt-2xl text-2xl font-semibold tracking-[-.032em] md:pt-xs md:text-3xl md:tracking-[-.034em]'
       isTitle
       {...props}
     >
@@ -61,7 +65,7 @@ export const MDXComponents = {
   h3: ({ children, ...props }: Children) => (
     <Text
       as='h3'
-      className='mb-sm mt-lg text-lg font-semibold'
+      className='mb-sm mt-lg text-lg font-semibold tracking-[-.018em]'
       isTitle
       {...props}
     >
@@ -69,7 +73,7 @@ export const MDXComponents = {
     </Text>
   ),
   p: ({ children }: Children) => (
-    <Text as='p' className='my-sm text-sm md:text-md'>
+    <Text as='p' className='my-sm text-sm tracking-[-.010em] md:text-md'>
       {children}
     </Text>
   ),
@@ -78,7 +82,9 @@ export const MDXComponents = {
     <ul className='my-sm pl-[20px]'>{children}</ul>
   ),
   li: ({ children }: Children) => (
-    <li className='mb-xs list-disc pl-1 text-md text-gray-10 '>{children}</li>
+    <li className='mb-xs list-disc pl-1 text-sm text-gray-10 md:text-md '>
+      {children}
+    </li>
   ),
   code: Code,
   Card,

--- a/apps/raddix/src/components/mdx.tsx
+++ b/apps/raddix/src/components/mdx.tsx
@@ -1,15 +1,10 @@
-import type { ReactNode } from 'react';
-import { useState } from 'react';
 import { componentsDemo } from '@/demo';
 import { Card, CardGroup } from './card';
 import { ApiTable } from './api-table';
 import { CodeBlock } from './code-block';
 import { Snippet } from './snippet';
 import { Code } from './code';
-
-export interface Children {
-  children?: ReactNode;
-}
+import type { Children } from '@/types/global';
 
 export interface TextProps extends Children {
   as: keyof JSX.IntrinsicElements;

--- a/apps/raddix/src/components/mdx.tsx
+++ b/apps/raddix/src/components/mdx.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react';
-import type { Language } from 'prism-react-renderer';
 import { useState } from 'react';
-import { Highlight, themes } from 'prism-react-renderer';
 import { componentsDemo } from '@/demo';
 import { Card, CardGroup } from './card';
 import { ApiTable } from './api-table';
 import { CodeBlock } from './code-block';
+import { Snippet } from './snippet';
+import { Code } from './code';
 
 export interface Children {
   children?: ReactNode;
@@ -39,8 +39,9 @@ export const TextPre = (props: Children) => {
   const children = props.children as TextPreProps;
 
   const classNameRo = children.props.className || '';
-  const code = children.props.children.trim();
+  const code = children.props.children;
   const language = classNameRo.replace(/language-/, '');
+
   const copyButtonStyles = isCopied
     ? 'bg-blue-60 text-white'
     : 'bg-white/70 text-gray-90';
@@ -57,42 +58,11 @@ export const TextPre = (props: Children) => {
     setTimeout(() => setIsCopied(false), 2000);
   };
 
-  return (
-    <div className='relative'>
-      <div className='group my-6 overflow-auto rounded-lg border border-solid border-white/10 bg-white/5 px-8 py-5 text-[1.05rem] scrollbar-thumb-gray-40 scrollbar-track-rounded-xl'>
-        <button
-          className={`absolute right-8 top-4 cursor-pointer rounded-lg border-0 px-2.5 py-0.5 text-sm opacity-0 transition-all duration-200 ease-in group-hover:opacity-100 active:scale-95 ${copyButtonStyles}`}
-          onClick={() => handleCopy(code)}
-        >
-          {isCopied ? '🎉 Copied!' : 'Copy'}
-        </button>
-        <Highlight code={code} language={language} theme={themes.dracula}>
-          {({ className, style, tokens, getLineProps, getTokenProps }) => (
-            <pre
-              className={className}
-              style={{
-                ...style,
-                backgroundColor: 'transparent'
-              }}
-              translate='no'
-            >
-              {tokens.map((line, i) => (
-                <div {...getLineProps({ line })} key={i} translate='no'>
-                  {line.map((token, key) => (
-                    <span
-                      {...getTokenProps({ token })}
-                      key={key}
-                      translate='no'
-                    />
-                  ))}
-                </div>
-              ))}
-            </pre>
-          )}
-        </Highlight>
-      </div>
-    </div>
-  );
+  if (language === 'sh' || language === 'bash') {
+    return <Snippet text={code} />;
+  }
+
+  return <CodeBlock source={code} language={language} />;
 };
 
 export const MDXComponents = {
@@ -133,6 +103,7 @@ export const MDXComponents = {
   li: ({ children }: Children) => (
     <li className='mb-xs list-disc pl-1 text-md text-gray-10 '>{children}</li>
   ),
+  code: Code,
   Card,
   CodeBlock,
   CardGroup,

--- a/apps/raddix/src/components/message.tsx
+++ b/apps/raddix/src/components/message.tsx
@@ -1,8 +1,6 @@
-interface MessageProps {
-  text: string;
-}
+import type { TextStr } from '@/types/global';
 
-export const Message = ({ text }: MessageProps) => {
+export const Message = ({ text }: TextStr) => {
   return (
     <div className='mr-md flex items-center gap-1 rounded-md bg-white/5 p-xs text-sm'>
       <span>🛠️</span>

--- a/apps/raddix/src/components/snippet.tsx
+++ b/apps/raddix/src/components/snippet.tsx
@@ -28,7 +28,7 @@ export const Snippet = ({ text }: TextStr) => {
   const { command, tokens } = getValues(text);
 
   return (
-    <div className='relative my-sm rounded-xl border border-gray-100 bg-gray-120 p-sm md:px-6 md:py-[21px]'>
+    <div className='relative my-sm rounded-xl border border-gray-100 bg-gray-120/80 p-sm md:px-6 md:py-[21px]'>
       <pre className='text-xs md:text-[15px]'>
         <div className='w-full'>
           <span className='text-[#56b6c2]'>{command}</span>

--- a/apps/raddix/src/components/snippet.tsx
+++ b/apps/raddix/src/components/snippet.tsx
@@ -1,0 +1,45 @@
+interface SnippetProps {
+  text: string;
+}
+
+const getTokenProps = (str: string) => {
+  if (
+    str === 'install' ||
+    str === 'i' ||
+    str === 'add' ||
+    str === 'dlx' ||
+    str === 'init' ||
+    str === 'npx' ||
+    str === 'run'
+  ) {
+    return { className: 'text-[#56b6c2]' };
+  }
+
+  return { className: 'text-[#D3D7CF]' };
+};
+
+const getValues = (str: string) => {
+  const tokens = str.split(' ');
+  const command = tokens.shift();
+
+  return { command, tokens };
+};
+
+export const Snippet = ({ text }: SnippetProps) => {
+  const { command, tokens } = getValues(text);
+
+  return (
+    <div className='my-sm rounded-xl border border-gray-100 bg-gray-120 p-sm md:px-6 md:py-[21px]'>
+      <pre className='text-xs md:text-[15px]'>
+        <div className='w-full'>
+          <span className='text-[#56b6c2]'>{command}</span>
+          {tokens.map((value, i) => (
+            <span key={i} {...getTokenProps(value)}>
+              &nbsp;{value}
+            </span>
+          ))}
+        </div>
+      </pre>
+    </div>
+  );
+};

--- a/apps/raddix/src/components/snippet.tsx
+++ b/apps/raddix/src/components/snippet.tsx
@@ -1,3 +1,5 @@
+import { Copy } from './copy';
+
 interface SnippetProps {
   text: string;
 }
@@ -29,7 +31,7 @@ export const Snippet = ({ text }: SnippetProps) => {
   const { command, tokens } = getValues(text);
 
   return (
-    <div className='my-sm rounded-xl border border-gray-100 bg-gray-120 p-sm md:px-6 md:py-[21px]'>
+    <div className='relative my-sm rounded-xl border border-gray-100 bg-gray-120 p-sm md:px-6 md:py-[21px]'>
       <pre className='text-xs md:text-[15px]'>
         <div className='w-full'>
           <span className='text-[#56b6c2]'>{command}</span>
@@ -40,6 +42,7 @@ export const Snippet = ({ text }: SnippetProps) => {
           ))}
         </div>
       </pre>
+      <Copy text={text} />
     </div>
   );
 };

--- a/apps/raddix/src/components/snippet.tsx
+++ b/apps/raddix/src/components/snippet.tsx
@@ -1,8 +1,5 @@
+import type { TextStr } from '@/types/global';
 import { Copy } from './copy';
-
-interface SnippetProps {
-  text: string;
-}
 
 const getTokenProps = (str: string) => {
   if (
@@ -27,7 +24,7 @@ const getValues = (str: string) => {
   return { command, tokens };
 };
 
-export const Snippet = ({ text }: SnippetProps) => {
+export const Snippet = ({ text }: TextStr) => {
   const { command, tokens } = getValues(text);
 
   return (

--- a/apps/raddix/src/styles/main.css
+++ b/apps/raddix/src/styles/main.css
@@ -7,7 +7,7 @@ code {
   font-family: 'JetBrains Mono', monospace;
 }
 
-.code {
+code {
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
 }

--- a/apps/raddix/src/styles/main.css
+++ b/apps/raddix/src/styles/main.css
@@ -6,3 +6,8 @@ pre,
 code {
   font-family: 'JetBrains Mono', monospace;
 }
+
+.code {
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}

--- a/apps/raddix/src/types/global.ts
+++ b/apps/raddix/src/types/global.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
-export interface TextProps {
-  text?: string;
+export interface TextStr {
+  text: string;
 }
 export interface Children {
   children?: ReactNode;

--- a/packages/vintex/src/pagenav/pagenav.tsx
+++ b/packages/vintex/src/pagenav/pagenav.tsx
@@ -93,7 +93,7 @@ export const PageNav = ({ locale, path }: PageNavProps) => {
 
   const pageNavTitle = locale === 'en' ? 'On this page' : 'En esta página';
   const activeHeading = useScrollSpy(headingIds, {
-    rootMargin: '0% 0% -90% 0%'
+    rootMargin: '-80px 0px -72% 0px'
   });
 
   return (

--- a/packages/vintex/src/pagenav/pagenav.tsx
+++ b/packages/vintex/src/pagenav/pagenav.tsx
@@ -24,7 +24,10 @@ const Tree = ({ navData, activeItem }: TreeProps) => {
     <ul className={`${childStyle}`}>
       {navData.map(item => {
         return (
-          <li key={`${item.name}-${item.depth}`} className='py-[4.5px] text-sm'>
+          <li
+            key={`${item.name}-${item.depth}`}
+            className='py-[4.5px] text-sm tracking-[-0.12px]'
+          >
             <a
               href={`#${item.id}`}
               className={

--- a/packages/vintex/src/sidebar/sidebar.tsx
+++ b/packages/vintex/src/sidebar/sidebar.tsx
@@ -16,7 +16,7 @@ export const SidebarMenu = ({ menu, currentRoute }: SideBarMenuProps) => {
       <ol>
         {menu.map(({ title, items }, i) => (
           <li key={`${title}-${i}`} className='pb-md'>
-            <span className='block pb-xs text-sm font-medium'>{title}</span>
+            <span className='mb-sm block text-sm font-medium'>{title}</span>
 
             <ol>
               {items.map((item, ii) => {
@@ -30,7 +30,7 @@ export const SidebarMenu = ({ menu, currentRoute }: SideBarMenuProps) => {
                     className={isActive ? styleLiActive : undefined}
                   >
                     <Link
-                      className={`block border-l-2 border-gray-100 py-[4.5px] pl-[14px] text-sm text-gray-30  ${
+                      className={`block border-l-[1px]  border-gray-100 py-[4.5px] pl-[14px] text-sm tracking-[-0.12px] text-gray-30  ${
                         isActive ? styleLinkActive : `hover:text-gray-20`
                       }`}
                       href={item.route.path}


### PR DESCRIPTION
The documentation design was improved with the following components:
- `Snippet`(new): A component to display a code snippet for the command line.
- `Code`(new): A component to highlight text as programming code.
- `CodeBlock`: The design of the buttons as an OS window was removed.
- `TextPre`: The component in charge of analyzing whether the code of the MDX file is `CodeBlock` or `Snipped`.
- `Copy`(new): A component to copy text to the clipboard.

Updated the `padding` and `letter-spacing` styles in the following components:
- `PageNav`
- `Aside`
- `Text`