### PR TITLE
Update i18n configuration

### DIFF
--- a/apps/raddix/next.config.js
+++ b/apps/raddix/next.config.js
@@ -1,12 +1,5 @@
 /** @type {import('next').NextConfig} */
-
 const nextConfig = {
-  reactStrictMode: true,
-  i18n: {
-    locales: ['en', 'es'],
-    defaultLocale: 'en',
-    localeDetection: false
-  },
   async redirects() {
     return [
       {

--- a/apps/raddix/src/components/language.tsx
+++ b/apps/raddix/src/components/language.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/router';
+import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
+import { locales, defaultLocale, useLocal } from '@/i18n';
 
 const codeLanguage = {
   en: 'English',
@@ -10,7 +13,22 @@ const codeLanguage = {
 type CodeLanguage = keyof typeof codeLanguage;
 
 export const Language = ({ showActive = false, menuAbsolute = true }) => {
-  const { locales, pathname, query, locale } = useRouter();
+  const currentPath = usePathname();
+  const currentLocale = useLocal();
+
+  const redirectedPathName = (locale: string) => {
+    // eslint-disable-next-line curly
+    if (!currentPath) return '/';
+
+    if (currentLocale === defaultLocale) {
+      return `/${locale}${currentPath}`;
+    } else {
+      const segments = currentPath.split('/');
+      segments[1] = locale;
+      return segments.join('/');
+    }
+  };
+
   const [isActive, setIsActive] = useState<boolean>(false);
 
   const refBtn = useRef<HTMLButtonElement>(null);
@@ -19,7 +37,9 @@ export const Language = ({ showActive = false, menuAbsolute = true }) => {
   const activeMenuStyle = isActive ? 'opacity-1 block' : 'hidden opacity-0';
 
   const activeItemStyle = (localName: string) => {
-    return locale === localName ? 'text-purple-40' : 'sm:hover:bg-gray-120';
+    return currentLocale === localName
+      ? 'text-purple-40'
+      : 'sm:hover:bg-gray-120';
   };
 
   const handleClickOutside = (e: MouseEvent | TouchEvent) => {
@@ -61,7 +81,9 @@ export const Language = ({ showActive = false, menuAbsolute = true }) => {
           height={22}
         />
         {showActive && (
-          <span className='px-1'>{codeLanguage[locale as CodeLanguage]}</span>
+          <span className='px-1'>
+            {codeLanguage[currentLocale as CodeLanguage]}
+          </span>
         )}
         <Image
           src={'/icons/bottom-arrow.svg'}
@@ -77,18 +99,14 @@ export const Language = ({ showActive = false, menuAbsolute = true }) => {
         } w-full min-w-max transition-opacity duration-150 ease-in sm:left-auto sm:right-0 ${activeMenuStyle}`}
       >
         <ul className='w-full space-y-1 rounded-md border-solid border-gray-50/30 bg-black sm:border sm:p-xs'>
-          {locales?.map(localName => {
+          {locales.map(localName => {
             return (
               <li
                 key={localName}
                 className={`${activeItemStyle(localName)} rounded-lg`}
               >
                 <Link
-                  href={{
-                    pathname,
-                    query
-                  }}
-                  locale={localName}
+                  href={redirectedPathName(localName)}
                   onClick={toggleMenu}
                   className='block px-sm text-xs leading-10 sm:px-md sm:leading-8'
                 >

--- a/apps/raddix/src/i18n/config.ts
+++ b/apps/raddix/src/i18n/config.ts
@@ -1,0 +1,4 @@
+export const i18nConfig = {
+  locales: ['en', 'es'],
+  defaultLocale: 'en'
+};

--- a/apps/raddix/src/i18n/index.ts
+++ b/apps/raddix/src/i18n/index.ts
@@ -1,0 +1,5 @@
+import { i18nConfig } from './config';
+
+export { useLocal } from './useLocal';
+
+export const { locales, defaultLocale } = i18nConfig;

--- a/apps/raddix/src/i18n/useLocal.ts
+++ b/apps/raddix/src/i18n/useLocal.ts
@@ -1,0 +1,12 @@
+import { usePathname } from 'next/navigation';
+import { i18nConfig } from './config';
+
+const { locales, defaultLocale } = i18nConfig;
+
+export const useLocal = (): string => {
+  const currentPath = usePathname();
+
+  const locale = locales.find(loc => currentPath?.includes(loc));
+
+  return locale ?? defaultLocale;
+};

--- a/apps/raddix/src/middleware.ts
+++ b/apps/raddix/src/middleware.ts
@@ -1,7 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { i18nConfig } from '@/i18n/config';
-
-const { locales, defaultLocale } = i18nConfig;
+import { locales, defaultLocale } from '@/i18n';
 
 export function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;

--- a/apps/raddix/src/middleware.ts
+++ b/apps/raddix/src/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { i18nConfig } from '@/i18n/config';
+
+const { locales, defaultLocale } = i18nConfig;
+
+export function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
+
+  // Verify if the path has a locale
+  const pathLocale = locales.find(
+    locale => pathname.startsWith(`/${locale}`) || pathname === `/${locale}`
+  );
+
+  if (pathLocale) {
+    // eslint-disable-next-line curly
+    if (pathLocale !== defaultLocale) return;
+
+    const pathWithoutLocale = pathname.slice(`/${pathLocale}`.length) || '/';
+    return NextResponse.redirect(
+      new URL(`${pathWithoutLocale}${search}`, req.url)
+    );
+  }
+
+  const newPath = `/${defaultLocale}${pathname}${search}`;
+  return NextResponse.rewrite(new URL(newPath, req.url));
+}
+
+export const config = {
+  matcher: '/((?!api|static|.*\\..*|_next).*)'
+};


### PR DESCRIPTION
Update Internationalization support for routing app in Next 14:

- The middleware configuration will prefix all of our routes with the current locale, except our default locale which will still be available in the unprefixed base route.
- Added useLocale hook for get currentlocale