### PR TITLE
feat(raddix): font optimization

### DIFF
--- a/apps/raddix/src/app/[lang]/fonts.ts
+++ b/apps/raddix/src/app/[lang]/fonts.ts
@@ -1,0 +1,21 @@
+import { Inter, JetBrains_Mono, Days_One } from 'next/font/google';
+
+export const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap'
+});
+
+export const jetbrainsMono = JetBrains_Mono({
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-jetbrains-mono'
+});
+
+export const daysOne = Days_One({
+  weight: ['400'],
+  display: 'swap',
+  variable: '--font-days-one'
+});
+
+export const fonts = `${inter.variable} ${jetbrainsMono.variable} ${daysOne.variable}`;

--- a/apps/raddix/src/app/[lang]/layout.tsx
+++ b/apps/raddix/src/app/[lang]/layout.tsx
@@ -8,7 +8,7 @@ import { Providers } from './providers';
 
 import '@/styles/main.css';
 import { getPkgManager } from '@/utils/get-pkg-manager';
-import { fonts } from './fonts';
+import { fonts } from '../fonts';
 
 export const metadata: Metadata = {
   title: {

--- a/apps/raddix/src/app/[lang]/layout.tsx
+++ b/apps/raddix/src/app/[lang]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import { Footer } from 'vintex';
 import { Header } from '@/components/header';
 import { locales } from '@/i18n';
@@ -9,6 +8,7 @@ import { Providers } from './providers';
 
 import '@/styles/main.css';
 import { getPkgManager } from '@/utils/get-pkg-manager';
+import { fonts } from './fonts';
 
 export const metadata: Metadata = {
   title: {
@@ -18,11 +18,6 @@ export const metadata: Metadata = {
   description: 'Collection of Essential React Hooks',
   keywords: ['react', 'hooks', 'react hooks', 'react hooks library', 'raddix']
 };
-
-const inter = Inter({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700']
-});
 
 export function generateStaticParams() {
   return locales.map(locale => ({ lang: locale }));
@@ -38,8 +33,8 @@ export default async function RootLayout({
   const headerProps = await getHeader(lang);
 
   return (
-    <html lang={lang} className={getTheme()}>
-      <body className={inter.className}>
+    <html lang={lang} className={`${getTheme()} ${fonts}`}>
+      <body className='font-inter'>
         <Providers
           defaultTheme={getTheme()}
           defaultPkgManager={getPkgManager()}

--- a/apps/raddix/src/app/fonts.ts
+++ b/apps/raddix/src/app/fonts.ts
@@ -7,12 +7,14 @@ export const inter = Inter({
 });
 
 export const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
   weight: ['400', '500', '600'],
   display: 'swap',
   variable: '--font-jetbrains-mono'
 });
 
 export const daysOne = Days_One({
+  subsets: ['latin'],
   weight: ['400'],
   display: 'swap',
   variable: '--font-days-one'

--- a/apps/raddix/src/components/logo.tsx
+++ b/apps/raddix/src/components/logo.tsx
@@ -4,8 +4,8 @@ export const Logo = ({ to = '/' }) => {
   return (
     <Link className='flex items-center gap-1.5' href={to}>
       <svg
-        width={22}
-        height={35}
+        // width={22}
+        height={30}
         viewBox='0 0 144 216'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'
@@ -101,7 +101,9 @@ export const Logo = ({ to = '/' }) => {
           </linearGradient>
         </defs>
       </svg>
-      <span className='text-[26px] font-semibold'>raddix</span>
+      <span className='font-days text-[24px] tracking-tight text-gray-90 dark:text-gray-10'>
+        raddix
+      </span>
     </Link>
   );
 };

--- a/apps/raddix/src/styles/main.css
+++ b/apps/raddix/src/styles/main.css
@@ -38,7 +38,7 @@ body::-webkit-scrollbar-thumb:active {
 
 pre,
 code {
-  font-family: 'JetBrains Mono', monospace;
+  @apply font-mono;
 }
 
 code {

--- a/apps/raddix/tailwind.config.ts
+++ b/apps/raddix/tailwind.config.ts
@@ -7,7 +7,16 @@ const config: Config = {
     './node_modules/vintex/dist/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',
     './src/app/**/*.{js,ts,jsx,tsx}'
-  ]
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        mono: ['var(--font-jetbrains-mono)'],
+        inter: ['var(--font-inter)'],
+        days: ['var(--font-days-one)']
+      }
+    }
+  }
 };
 
 export default config;


### PR DESCRIPTION
Two new fonts added:
- DaysOne for the logo font.
- Jetbrains Mono for the source of bash and code blocks.

All fonts are optimized by next and used by tailwind css through css variables