### PR TITLE
fix(raddix): i18n and dark mode

### DIFF
--- a/apps/raddix/src/hooks/useDarkMode.ts
+++ b/apps/raddix/src/hooks/useDarkMode.ts
@@ -11,8 +11,7 @@ export const useDarkMode = () => {
     const theme = isDarkMode ? 'light' : 'dark';
     setCookie('theme', theme, 365);
     setIsDarkMode(state => !state);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isDarkMode]);
 
   return { isDarkMode, toggle };
 };

--- a/apps/raddix/src/i18n/useLocale.ts
+++ b/apps/raddix/src/i18n/useLocale.ts
@@ -6,7 +6,9 @@ const { locales, defaultLocale } = i18nConfig;
 export const useLocale = (): string => {
   const currentPath = usePathname();
 
-  const locale = locales.find(loc => currentPath?.includes(loc));
+  const locale = locales.find(local => {
+    return currentPath === `/${local}` || currentPath.startsWith(`/${local}/`);
+  });
 
   return locale ?? defaultLocale;
 };


### PR DESCRIPTION
This PR fixes the following:

- find the exact location of the locales in the path
- Missing `isDarkMode` variable in `useCallback` dependency of `toggleTheme` causes unnecessary flickering when switching themes.