### PR TITLE
feat: customizing the selector dark mode

### DIFF
--- a/apps/raddix/next.config.js
+++ b/apps/raddix/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['next-mdx-remote'],
+  transpilePackages: ['next-mdx-remote', 'vintex'],
   async redirects() {
     return [
       {

--- a/apps/raddix/src/app/[lang]/layout.tsx
+++ b/apps/raddix/src/app/[lang]/layout.tsx
@@ -34,7 +34,7 @@ export default async function RootLayout({
   const headerProps = await getHeader(lang);
 
   return (
-    <html lang={lang} className={`${getTheme()} ${fonts}`}>
+    <html lang={lang} data-theme={getTheme()} className={fonts}>
       <body className='font-inter'>
         <Providers
           defaultTheme={getTheme()}

--- a/apps/raddix/src/hooks/useDarkMode.ts
+++ b/apps/raddix/src/hooks/useDarkMode.ts
@@ -7,8 +7,8 @@ export const useDarkMode = () => {
   const [isDarkMode, setIsDarkMode] = useState(defaultTheme === 'dark');
 
   const toggle = useCallback(() => {
-    document.documentElement.classList.toggle('dark');
     const theme = isDarkMode ? 'light' : 'dark';
+    document.documentElement.dataset.theme = theme;
     setCookie('theme', theme, 365);
     setIsDarkMode(state => !state);
   }, [isDarkMode]);

--- a/apps/raddix/src/utils/get-theme.ts
+++ b/apps/raddix/src/utils/get-theme.ts
@@ -5,5 +5,5 @@ export const getTheme = () => {
   if (!theme) {
     return 'dark';
   }
-  return theme.value === 'dark' ? 'dark' : '';
+  return theme.value;
 };

--- a/settings/tailwind/tailwind.config.ts
+++ b/settings/tailwind/tailwind.config.ts
@@ -3,7 +3,7 @@ import { colors } from '@vintach/colors';
 import scrollbarPlugin from 'tailwind-scrollbar';
 
 const config: Omit<Config, 'content'> = {
-  darkMode: 'selector',
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
     screens: {
       sm: '40rem', //640px


### PR DESCRIPTION
Customizing the dark mode selector in tailwindcss to `[data-theme="dark"]`