### PR TITLE
fix(raddix): Application error in home page

### DIFF
--- a/apps/raddix/src/app/[lang]/guide/[slug]/opengraph-image.tsx
+++ b/apps/raddix/src/app/[lang]/guide/[slug]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { getMdxFileBySlug } from '@/lib/content';
 import { OG } from '@/components/og';
-import { getFileSync } from '@/utils/get-file';
+import { getFile } from '@/utils/get-file';
 
 interface Props {
   params: { slug: string; lang: string };
@@ -14,9 +14,9 @@ export const size = {
 };
 export const contentType = 'image/png';
 
-export default function Image({ params }: Props) {
-  const interBold = getFileSync('assets', 'Inter-Bold.ttf');
-  const interRegular = getFileSync('assets', 'Inter-Regular.ttf');
+export default async function Image({ params }: Props) {
+  const interBold = await getFile('assets/Inter-Bold.ttf');
+  const interRegular = await getFile('assets/Inter-Regular.ttf');
   const { meta } = getMdxFileBySlug({ params, filePath: 'guide' });
   const { title, description } = meta;
 

--- a/apps/raddix/src/app/[lang]/hooks/[slug]/opengraph-image.tsx
+++ b/apps/raddix/src/app/[lang]/hooks/[slug]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { getMdxFileRepoBySlug } from '@/lib/content';
 import { OG } from '@/components/og';
-import { getFileSync } from '@/utils/get-file';
+import { getFile } from '@/utils/get-file';
 
 const configRepo = {
   repo: 'raddix',
@@ -21,8 +21,8 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image({ params }: Props) {
-  const interBold = getFileSync('assets', 'Inter-Bold.ttf');
-  const interRegular = getFileSync('assets', 'Inter-Regular.ttf');
+  const interBold = await getFile('assets/Inter-Bold.ttf');
+  const interRegular = await getFile('assets/Inter-Regular.ttf');
   const { meta } = await getMdxFileRepoBySlug({ params, ...configRepo });
   const { title, description } = meta;
 

--- a/apps/raddix/src/app/[lang]/opengraph-image.tsx
+++ b/apps/raddix/src/app/[lang]/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from 'next/og';
 import { getConfigFile } from '@/lib/content';
 import { OG } from '@/components/og';
 import { configSite } from 'content/site/_config';
-import { getFileSync } from '@/utils/get-file';
+import { getFile } from '@/utils/get-file';
 
 interface Props {
   params: { lang: string };
@@ -15,8 +15,8 @@ export const size = {
 };
 export const contentType = 'image/png';
 
-export default function Image({ params: { lang } }: Props) {
-  const interBold = getFileSync('assets', 'Inter-Bold.ttf');
+export default async function Image({ params: { lang } }: Props) {
+  const interBold = await getFile('assets/Inter-Bold.ttf');
   const { meta } = getConfigFile({ lang, dirPath: 'content/site' });
 
   return new ImageResponse(

--- a/apps/raddix/src/i18n/utils.ts
+++ b/apps/raddix/src/i18n/utils.ts
@@ -9,7 +9,9 @@ export const getLocaleUrl = (
 ): string => {
   url = url === '/' ? '' : url;
   prefix = !prefix ? '' : prefix;
-  return lang === defaultLocale ? `${prefix}${url}` : `${prefix}/${lang}${url}`;
+  return lang === defaultLocale
+    ? `${prefix}/${url}`
+    : `${prefix}/${lang}${url}`;
 };
 
 type LocaleUrls = Record<string, string>;

--- a/apps/raddix/src/lib/content.ts
+++ b/apps/raddix/src/lib/content.ts
@@ -43,9 +43,11 @@ export const getConfigFileRepo = async ({
 
   try {
     if (process.env.NODE_ENV === 'development') {
-      fileData = await getFile(
-        `../../../${repo}/${contentDirPath}${isLang}/_config.json`
-      );
+      fileData = (
+        await getFile(
+          `../../../${repo}/${contentDirPath}${isLang}/_config.json`
+        )
+      ).toString();
     } else {
       fileData = await getRemoteFile({
         owner,
@@ -108,7 +110,9 @@ export const getMdxFileRepoBySlug = async ({
 
   try {
     if (process.env.NODE_ENV === 'development') {
-      fileData = await getFile(`${filePath}${lang}/${flattenedPath}.mdx`);
+      fileData = (
+        await getFile(`${filePath}${lang}/${flattenedPath}.mdx`)
+      ).toString();
     } else {
       fileData = await getRemoteFile({
         owner,

--- a/apps/raddix/src/utils/get-file.ts
+++ b/apps/raddix/src/utils/get-file.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs/promises';
 import { glob } from 'glob';
-import { readFileSync } from 'fs';
 
 interface FileOps {
   contentDirPath: string;
@@ -29,12 +28,6 @@ export const getFiles = ({ contentDirPath, pattern }: FileOps) => {
 export const getFile = async (filePath: string) => {
   const localFilePath = path.join(process.cwd(), filePath);
   const file = await fs.readFile(localFilePath);
-  return file.toString();
-};
-
-export const getFileSync = (...paths: string[]): Buffer => {
-  const filePath = path.join(process.cwd(), ...paths);
-  const file = readFileSync(filePath);
   return file;
 };
 


### PR DESCRIPTION
Nextjs requires that the call to the font files in `graph-image.tsx` be asynchronous and the error on the home page was because the getLocaleUrl function returned an empty string which is not valid for a route